### PR TITLE
chore: Use new BGS firehose websocket endpoint

### DIFF
--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -38,7 +38,7 @@ type Firehose struct {
 func New(postChan chan interface{}, context context.Context) *Firehose {
 	dialer := websocket.DefaultDialer
 	firehose := &Firehose{
-		address:  "wss://bsky.social/xrpc/com.atproto.sync.subscribeRepos",
+		address:  "wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos",
 		dialer:   dialer,
 		postChan: postChan,
 		context:  context,


### PR DESCRIPTION
Bluesky has launched their new big graph server in production. In order to get all posts from all personal data servers the feed generator should listen to the BGS moving forward.