### PR TITLE
fix: Firehose liveness probe

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -9,6 +9,7 @@ import (
 	"norsky/firehose"
 	"norsky/models"
 	"os"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -38,9 +39,11 @@ Prints all other log messages to stderr.`,
 			// Channel for subscribing to bluesky posts
 			postChan := make(chan interface{})
 
+			ticker := time.NewTicker(5 * time.Minute)
+
 			go func() {
 				fmt.Println("Subscribing to firehose...")
-				firehose.Subscribe(ctx.Context, postChan, -1)
+				firehose.Subscribe(ctx.Context, postChan, ticker, -1)
 			}()
 
 			go func() {


### PR DESCRIPTION
Sometimes, the firehose will go silent without any errors being returned anywhere. To avoid the feed server simply stopping up, the subscribe function now accepts a ticker reset for every new post the Firehose receives. If the ticker ever reaches its 5-minute mark, a separate go routine in the subscribe and serve command modules will reset the firehose and make a new connection.

This way, if the firehose is silent for 5 minutes or more, the Norsky server will automatically reconnect.