### PR TITLE
feat: Detect false negatives flag

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -43,7 +43,7 @@ Prints all other log messages to stderr.`,
 
 			go func() {
 				fmt.Println("Subscribing to firehose...")
-				firehose.Subscribe(ctx.Context, postChan, ticker, -1)
+				firehose.Subscribe(ctx.Context, postChan, ticker, -1, ctx.Bool("detect-false-negatives"))
 			}()
 
 			go func() {


### PR DESCRIPTION
Add a new flag to run language detection on all posts in the firehose. This allows the feed to include false negatives, at the cost of including some false positives as language detection on short posts is not perfect. We make it a flag so it is possible to run feed generator in old mode where it only looks at posts tagged with Norwegian. We still check for false positives in the old mode.

Refactor the firehose module to be much more readable. Move the post processing and language detection logic out into a separate receiver method to make the event processor function much more readable.