### PR TITLE
feat: Configuration based feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ feed.db
 node_modules
 server/dist
 queries/
+feeds.toml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A dashboard is available at the root of the server `/`.
 The dashboard shows interesting statistics about the feed and Norwegian language posts.
 It is written in TypeScript using Solid.js and Tailwind CSS.
 
+> [!IMPORTANT]
+> Version 1.0.0 introduces breaking changes that require a new `feeds.toml` configuration file. The feed configuration has been moved from hardcoded values to a TOML file that allows you to configure multiple feeds with different language settings. See the example configuration in `feeds.example.toml` for reference.
+
+
+
 ## Installation
 
 The feed server is a standalone go binary that you can run on your machine.
@@ -73,11 +78,39 @@ norsky serve --hostname yourdomain.tld --port 8080 --database /path/to/db/feed.d
 docker run -d \
     --env=NORSKY_HOSTNAME="yourdomain.tld" \
     --env NORSKY_DATABASE="/db/feed.db" \
+    --env NORSKY_CONFIG="/feeds.toml" \
     --name norsky \
     -p 3000:3000 \
     -v /path/to/db:/db \
+    -v /path/to/feeds.toml:/feeds.toml \
     ghrc.io/snorreio/norsky:latest
 ```
+
+## Configuration
+
+Since version 1.0 the Norsky feed generator supports dynamically loading feeds from a `feeds.toml` file.
+Each feed is defined in a `[[feeds]]` section and currently requires the following fields:
+
+- `id` - The id of the feed.
+- `display_name` - The display name of the feed.
+- `description` - The description of the feed.
+- `avatar_path` - The path to the avatar image for the feed.
+- `languages` - The languages supported by the feed.
+
+If you want to run a german language feed you can add the following to your `feeds.toml` file:
+
+```toml
+[[feeds]]
+id = "german"
+display_name = "German"
+description = "A feed of Bluesky posts written in German"
+avatar_path = "./assets/avatar.png"
+languages = ["de"] # Note that you should use all the german language codes as used by the Bluesky API
+```
+
+In the future other fields will be added as optional fields to the feed definition.
+This will allow for filtering on other properties of Bluesky posts.
+
 
 ## Development
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+type FeedConfig struct {
+	ID          string   `toml:"id"`
+	DisplayName string   `toml:"display_name"`
+	Description string   `toml:"description"`
+	AvatarPath  string   `toml:"avatar_path,omitempty"`
+	Languages   []string `toml:"languages"`
+}
+
+type Config struct {
+	Feeds []FeedConfig `toml:"feeds"`
+}
+
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file: %w", err)
+	}
+
+	var config Config
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	return &config, nil
+}

--- a/db/reader.go
+++ b/db/reader.go
@@ -24,7 +24,7 @@ func NewReader(database string) *Reader {
 	}
 }
 
-func (reader *Reader) GetFeed(lang string, limit int, postId int64) ([]models.FeedPost, error) {
+func (reader *Reader) GetFeed(langs []string, limit int, postId int64) ([]models.FeedPost, error) {
 
 	// Return next limit posts after cursor, ordered by created_at and uri
 
@@ -35,11 +35,11 @@ func (reader *Reader) GetFeed(lang string, limit int, postId int64) ([]models.Fe
 			sb.LessThan("id", postId),
 		)
 	}
-	if lang != "" {
-		sb.Where(sb.Equal("language", lang))
+	if len(langs) > 0 {
+		sb.Join("post_languages", "posts.id = post_languages.post_id")
+		sb.Where(sb.In("language", langs))
+		sb.GroupBy("posts.id")
 	}
-	sb.Join("post_languages", "posts.id = post_languages.post_id")
-	sb.GroupBy("posts.id")
 	sb.Limit(limit).OrderBy("id").Desc()
 
 	sql, args := sb.BuildWithFlavor(sqlbuilder.Flavor(sqlbuilder.SQLite))

--- a/feeds.example.toml
+++ b/feeds.example.toml
@@ -1,0 +1,27 @@
+[[feeds]]
+id = "english"
+display_name = "English"
+description = "A feed of Bluesky posts written in English"
+avatar_path = "./assets/avatar.png"
+languages = ["en", "en-US", "en-GB", "en-AU", "en-CA", "en-NZ", "en-ZA"]
+
+[[feeds]]
+id = "nynorsk"
+display_name = "Nynorsk"
+description = "A feed of Bluesky posts written in Norwegian nynorsk"
+avatar_path = "./assets/avatar.png"
+languages = ["nn"]
+
+[[feeds]]
+id = "sami"
+display_name = "Sami"
+description = "A feed of Bluesky posts written in Sami"
+avatar_path = "./assets/avatar.png"
+languages = ["se"]
+
+[[feeds]]
+id = "all"
+display_name = "Norsk (Norwegian)"
+description = "A feed of Bluesky posts written in Norwegian bokmål, nynorsk and sami"
+avatar_path = "./assets/avatar.png"
+languages = ["nb", "nn", "no", "se"]

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.3
 
 require (
+	github.com/BurntSushi/toml v1.4.0
 	github.com/bluesky-social/indigo v0.0.0-20241223053147-c130614850e5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cqroot/prompt v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=


### PR DESCRIPTION
Allow users of the Norsky feed generator to specify feeds via toml config. This allows defining new feeds on the fly without making code changes. Currently the feed generator supports filtering on language. In the future other types of inputs can be used like filtering on hashtags and similar.